### PR TITLE
Fix Issue#68 with rapidjson when compiling with document.h

### DIFF
--- a/dep/include/rapidjson/document.h
+++ b/dep/include/rapidjson/document.h
@@ -316,8 +316,8 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
+    //GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+    GenericStringRef& operator=(const GenericStringRef& rhs) = delete;
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 


### PR DESCRIPTION
## Issue this resolves
<!-- Please link to an issue. Create one first if needed. -->
- Closes #68

## Code Type
- [ ]  SQL
- [x]  Core

## Description
`GenericStringRef` is designed as a lightweight, immutable string reference. Reassignment semantics do not belong on it, and deleting the operator is the cleanest solution assuming nothing in the codebase reassigns a `GenericStringRef` after construction.

```cpp
GenericStringRef& operator=(const GenericStringRef&) = delete;
```
### Files changed
| File | Change |
|---|---|
| `dep/include/rapidjson/document.h` | deleting the operator |