### PR TITLE
Add Nix Flake for reproducible environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1775487831,
+        "narHash": "sha256-2lguQpLPQaxpQCJjXhmEEAfabwsAhkP29Z7fgLzHARA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "76be9608a7f4d6c985d28b0e7be903ae2547df3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767028467,
+        "narHash": "sha256-7G+2aXClSMaTY1ogpX14CAxjRsvyVzpE0GRwL71WO7g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1cabc318c11299f07ca53e3cb719854682fe6eb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,417 @@
+{
+  description = "Tortoise-WoW flake for NixOS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nix2container.url = "github:nlewo/nix2container";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix2container,
+    }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSystem =
+        f: nixpkgs.lib.genAttrs supportedSystems (system: f nixpkgs.legacyPackages.${system});
+
+      mkBuildInputs =
+        pkgs: with pkgs; [
+          ace
+          boost
+          mariadb-connector-c
+          openssl
+          zlib
+        ];
+
+      mkNativeBuildInputs =
+        pkgs: with pkgs; [
+          cmake
+          git
+          ninja
+          pkg-config
+        ];
+
+      makeTortoise =
+        pkgs: cmakeFlags:
+        let
+          buildInputs = mkBuildInputs pkgs;
+          nativeBuildInputs = mkNativeBuildInputs pkgs;
+        in
+        pkgs.stdenv.mkDerivation {
+          pname = "tortoise-wow";
+          version = "unstable-2025-05-07";
+
+          src = ./.;
+
+          inherit nativeBuildInputs buildInputs;
+
+          postPatch = ''
+            substituteInPlace CMakeLists.txt \
+              --replace "find_package(MySQL REQUIRED)" "set(MySQL_FOUND TRUE)" \
+              --replace "-march=native" "-march=x86-64"
+
+            # Force it to use CMake's built-in FindOpenSSL instead of the bundled one
+            rm cmake/FindOpenSSL.cmake
+
+            # Add missing includes for C++17 features
+            for f in src/game/AccountMgr.h src/game/Conditions.h src/game/DynamicVisibilityMgr.h src/game/ObjectMgr.h src/game/Objects/Player.h src/game/Logging/DatabaseLogger.hpp src/shared/Database/AutoUpdater.cpp; do
+              sed -i '1i #include <optional>' "$f"
+            done
+          '';
+
+          NIX_LDFLAGS = "-lmariadb -L${pkgs.mariadb-connector-c.out}/lib/mariadb";
+          env.CXXFLAGS = "-I${pkgs.mariadb-connector-c.dev}/include/mariadb -Wno-error=template-body";
+
+          inherit cmakeFlags;
+
+          installPhase = ''
+            mkdir -p $out/bin $out/etc
+            ninja install
+            find $out -name "*.conf.dist" -exec cp {} $out/etc/ \;
+          '';
+        };
+    in
+    {
+      packages = nixpkgs.lib.genAttrs supportedSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nix2containerPkgs = nix2container.packages.${system};
+
+          # Build the main package
+          tortoiseWowPkg = makeTortoise pkgs [
+            "-G Ninja"
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DUSE_PCH=OFF"
+            "-DUSE_STD_MALLOC=ON"
+            "-DUSE_EXTRACTORS=ON"
+            "-DBUILD_FOR_HOST_CPU=OFF"
+            "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+            "-DOPENSSL_ROOT_DIR=${pkgs.openssl.dev}"
+            "-DOPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include"
+          ];
+
+          tortoiseWowDevPkg = makeTortoise pkgs [
+            "-G Ninja"
+            "-DCMAKE_BUILD_TYPE=Debug"
+            "-DUSE_PCH=OFF"
+            "-DUSE_STD_MALLOC=ON"
+            "-DUSE_EXTRACTORS=ON"
+            "-DBUILD_FOR_HOST_CPU=OFF"
+            "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
+            "-DOPENSSL_ROOT_DIR=${pkgs.openssl.dev}"
+            "-DOPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include"
+            "-DALLOW_TURTLE_ADDONS=ON"
+            "-DUSE_REALMMERGE=ON"
+          ];
+
+          # Base layer with runtime dependencies (shared between realmd and mangosd)
+          base-layer = nix2containerPkgs.nix2container.buildLayer {
+            name = "tortoise-wow-base";
+            deps = mkBuildInputs pkgs;
+          };
+
+          # Realm server wrapper script
+          realmd-wrapper = pkgs.runCommand "start-realmd" { } ''
+                          mkdir -p $out/bin
+                          cat > $out/bin/start-realmd <<EOF
+            #!${pkgs.bash}/bin/sh
+            exec ${tortoiseWowPkg}/bin/realmd -c /etc/realmd.conf
+            EOF
+                          chmod +x $out/bin/start-realmd
+          '';
+
+          # World server wrapper script
+          mangosd-wrapper = pkgs.runCommand "start-mangosd" { } ''
+                          mkdir -p $out/bin
+                          cat > $out/bin/start-mangosd <<EOF
+            #!${pkgs.bash}/bin/sh
+            exec ${tortoiseWowPkg}/bin/mangosd -c /etc/mangosd.conf
+            EOF
+                          chmod +x $out/bin/start-mangosd
+          '';
+
+          # Combined root for realmd (tortoise-wow + wrapper)
+          realmd-root = pkgs.symlinkJoin {
+            name = "realmd-root";
+            paths = [
+              tortoiseWowPkg
+              realmd-wrapper
+            ];
+          };
+
+          # Combined root for mangosd (tortoise-wow + wrapper)
+          mangosd-root = pkgs.symlinkJoin {
+            name = "mangosd-root";
+            paths = [
+              tortoiseWowPkg
+              mangosd-wrapper
+            ];
+          };
+          # Realm server (game server) Docker image - nix2container version
+          realmd-image = nix2containerPkgs.nix2container.buildImage {
+            name = "tortoise-wow-realmd";
+            tag = "latest";
+            layers = [ base-layer ];
+            copyToRoot = realmd-root;
+            config = {
+              entrypoint = [ "/bin/start-realmd" ];
+              ExposedPorts = {
+                "3724/tcp" = { };
+              };
+            };
+          };
+
+          # World server Docker image - nix2container version
+          mangosd-image = nix2containerPkgs.nix2container.buildImage {
+            name = "tortoise-wow-mangosd";
+            tag = "latest";
+            layers = [ base-layer ];
+            copyToRoot = mangosd-root;
+            config = {
+              entrypoint = [ "/bin/start-mangosd" ];
+              ExposedPorts = {
+                "8085/tcp" = { };
+              };
+            };
+          };
+
+          # Realm server Docker image - dockerTools version (produces .tar.gz)
+          realmd-image-tar = pkgs.dockerTools.buildImage {
+            name = "tortoise-wow-realmd";
+            tag = "latest";
+            copyToRoot = [
+              realmd-root
+              pkgs.bash
+              pkgs.coreutils
+            ];
+            config = {
+              Entrypoint = [ "/bin/start-realmd" ];
+              ExposedPorts = {
+                "3724/tcp" = { };
+              };
+            };
+          };
+
+          # World server Docker image - dockerTools version (produces .tar.gz)
+          mangosd-image-tar = pkgs.dockerTools.buildImage {
+            name = "tortoise-wow-mangosd";
+            tag = "latest";
+            copyToRoot = [
+              mangosd-root
+              pkgs.bash
+              pkgs.coreutils
+            ];
+            config = {
+              Entrypoint = [ "/bin/start-mangosd" ];
+              ExposedPorts = {
+                "8085/tcp" = { };
+              };
+            };
+          };
+          # Dev wrapper scripts
+          realmd-dev-wrapper = pkgs.runCommand "start-realmd" { } ''
+            mkdir -p $out/bin
+            cat > $out/bin/start-realmd <<EOF
+            #!${pkgs.bash}/bin/sh
+            exec ${tortoiseWowDevPkg}/bin/realmd -c /etc/realmd.conf
+            EOF
+            chmod +x $out/bin/start-realmd
+          '';
+
+          mangosd-dev-wrapper = pkgs.runCommand "start-mangosd" { } ''
+            mkdir -p $out/bin
+            cat > $out/bin/start-mangosd <<EOF
+            #!${pkgs.bash}/bin/sh
+            exec ${tortoiseWowDevPkg}/bin/mangosd -c /etc/mangosd.conf
+            EOF
+            chmod +x $out/bin/start-mangosd
+          '';
+
+          realmd-dev-root = pkgs.symlinkJoin {
+            name = "realmd-dev-root";
+            paths = [
+              tortoiseWowDevPkg
+              realmd-dev-wrapper
+            ];
+          };
+
+          mangosd-dev-root = pkgs.symlinkJoin {
+            name = "mangosd-dev-root";
+            paths = [
+              tortoiseWowDevPkg
+              mangosd-dev-wrapper
+            ];
+          };
+
+          realmd-image-tar-dev = pkgs.dockerTools.buildImage {
+            name = "tortoise-wow-realmd-dev";
+            tag = "latest";
+            copyToRoot = [
+              realmd-dev-root
+              pkgs.bash
+              pkgs.coreutils
+            ];
+            config = {
+              Entrypoint = [ "/bin/start-realmd" ];
+              ExposedPorts = {
+                "3724/tcp" = { };
+              };
+            };
+          };
+
+          mangosd-image-tar-dev = pkgs.dockerTools.buildImage {
+            name = "tortoise-wow-mangosd-dev";
+            tag = "latest";
+            copyToRoot = [
+              mangosd-dev-root
+              pkgs.bash
+              pkgs.coreutils
+            ];
+            config = {
+              Entrypoint = [ "/bin/start-mangosd" ];
+              ExposedPorts = {
+                "8086/tcp" = { };
+              };
+            };
+          };
+        in
+        {
+          tortoise-wow = tortoiseWowPkg;
+          default = tortoiseWowPkg;
+          inherit realmd-image mangosd-image;
+          inherit realmd-image-tar mangosd-image-tar;
+          inherit realmd-image-tar-dev mangosd-image-tar-dev;
+        }
+      );
+
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          name = "tortoise-wow-dev";
+          buildInputs = mkBuildInputs pkgs;
+          packages = mkNativeBuildInputs pkgs;
+        };
+      });
+
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        let
+          cfg = config.services.tortoise-wow;
+        in
+        {
+          options.services.tortoise-wow = {
+            enable = lib.mkEnableOption "Tortoise-WoW server";
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = self.packages.${pkgs.system}.tortoise-wow;
+            };
+            dataPath = lib.mkOption {
+              type = lib.types.path;
+              default = "/var/lib/tortoise-wow";
+            };
+            realmName = lib.mkOption {
+              type = lib.types.str;
+              default = "Tortoise-WoW";
+            };
+            address = lib.mkOption {
+              type = lib.types.str;
+              default = "127.0.0.1";
+            };
+            db_username = lib.mkOption {
+              type = lib.types.str;
+              default = "mangos";
+            };
+            db_password = lib.mkOption {
+              type = lib.types.str;
+              default = "mangos";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            users.users.tortoise-wow = {
+              isSystemUser = true;
+              group = "tortoise-wow";
+              extraGroups = [ "mysql" ];
+            };
+            users.groups.tortoise-wow = { };
+
+            services.mysql = {
+              enable = true;
+              package = lib.mkDefault pkgs.mariadb;
+            };
+            # Needs new db init for turtle. Below is vmangos example
+            # systemd.services.tortoise-wow-db-init = {
+            #   description = "Tortoise-WoW Database Initialization";
+            #   after = [ "mysql.service" ];
+            #   requires = [ "mysql.service" ];
+            #   wantedBy = [ "multi-user.target" ];
+            #   unitConfig.ConditionPathExists = "!${cfg.dataPath}/.db-initialized";
+            #   serviceConfig = {
+            #     Type = "oneshot";
+            #     RemainAfterExit = true;
+            #     ExecStart = pkgs.writeShellScript "tortoise-wow-db-init" ''
+            #       set -e
+            #       PATH=${pkgs.mariadb}/bin:/run/current-system/sw/bin
+            #       ${pkgs.mariadb}/bin/mariadb -u root <<EOF
+            #       CREATE DATABASE IF NOT EXISTS \`realmd\`;
+            #       CREATE DATABASE IF NOT EXISTS \`mangos\`;
+            #       CREATE DATABASE IF NOT EXISTS \`characters\`;
+            #       CREATE DATABASE IF NOT EXISTS \`logs\`;
+            #       CREATE USER IF NOT EXISTS '${cfg.db_username}'@'localhost' IDENTIFIED BY '${cfg.db_password}';
+            #       GRANT ALL PRIVILEGES ON \`realmd\`.* TO '${cfg.db_username}'@'localhost';
+            #       GRANT ALL PRIVILEGES ON \`mangos\`.* TO '${cfg.db_username}'@'localhost';
+            #       GRANT ALL PRIVILEGES ON \`characters\`.* TO '${cfg.db_username}'@'localhost';
+            #       GRANT ALL PRIVILEGES ON \`logs\`.* TO '${cfg.db_username}'@'localhost';
+            #       FLUSH PRIVILEGES;
+            #       EOF
+            #
+            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} realmd     < ${cfg.dataPath}/sql/base/realmd.sql
+            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} characters < ${cfg.dataPath}/sql/base/characters.sql
+            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} mangos     < ${cfg.dataPath}/sql/base/mangos.sql
+            #
+            #       chown -R tortoise-wow ${cfg.dataPath}
+            #       touch ${cfg.dataPath}/.db-initialized
+            #     '';
+            #   };
+            # };
+
+            systemd.services.tortoise-wow-realmd = {
+              after = [
+                "network.target"
+                "mysql.service"
+                "tortoise-wow-db-init.service"
+              ];
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                ExecStart = "${cfg.package}/bin/realmd -c ${cfg.dataPath}/etc/realmd.conf";
+                WorkingDirectory = cfg.dataPath;
+                User = "tortoise-wow";
+                Restart = "always";
+              };
+            };
+            # BUGGED, needs tty, stdin for mangosd console to not reboot each time. Solved for docker, not systemd (yet)
+            systemd.services.tortoise-wow-mangosd = {
+              after = [ "tortoise-wow-realmd.service" ];
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                ExecStart = "${cfg.package}/bin/mangosd -c ${cfg.dataPath}/etc/mangosd.conf";
+                WorkingDirectory = cfg.dataPath;
+                User = "tortoise-wow";
+                Restart = "always";
+              };
+            };
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,7 @@
         in
         pkgs.stdenv.mkDerivation {
           pname = "tortoise-wow";
-          version = "unstable-2025-05-07";
-
+          version = "unstable-${self.shortRev}";
           src = ./.;
 
           inherit nativeBuildInputs buildInputs;
@@ -412,7 +411,7 @@
                 Restart = "always";
               };
             };
-            # MANGOSD MUST NOT BE IN CONSOLE MODE 
+            # MANGOSD MUST NOT BE IN CONSOLE MODE Console.Enable = 0 
             systemd.services.tortoise-wow-mangosd = {
               after = [ "tortoise-wow-realmd.service" ];
               wantedBy = [ "multi-user.target" ];

--- a/flake.nix
+++ b/flake.nix
@@ -350,42 +350,54 @@
               enable = true;
               package = lib.mkDefault pkgs.mariadb;
             };
-            # Needs new db init for turtle. Below is vmangos example
-            # systemd.services.tortoise-wow-db-init = {
-            #   description = "Tortoise-WoW Database Initialization";
-            #   after = [ "mysql.service" ];
-            #   requires = [ "mysql.service" ];
-            #   wantedBy = [ "multi-user.target" ];
-            #   unitConfig.ConditionPathExists = "!${cfg.dataPath}/.db-initialized";
-            #   serviceConfig = {
-            #     Type = "oneshot";
-            #     RemainAfterExit = true;
-            #     ExecStart = pkgs.writeShellScript "tortoise-wow-db-init" ''
-            #       set -e
-            #       PATH=${pkgs.mariadb}/bin:/run/current-system/sw/bin
-            #       ${pkgs.mariadb}/bin/mariadb -u root <<EOF
-            #       CREATE DATABASE IF NOT EXISTS \`realmd\`;
-            #       CREATE DATABASE IF NOT EXISTS \`mangos\`;
-            #       CREATE DATABASE IF NOT EXISTS \`characters\`;
-            #       CREATE DATABASE IF NOT EXISTS \`logs\`;
-            #       CREATE USER IF NOT EXISTS '${cfg.db_username}'@'localhost' IDENTIFIED BY '${cfg.db_password}';
-            #       GRANT ALL PRIVILEGES ON \`realmd\`.* TO '${cfg.db_username}'@'localhost';
-            #       GRANT ALL PRIVILEGES ON \`mangos\`.* TO '${cfg.db_username}'@'localhost';
-            #       GRANT ALL PRIVILEGES ON \`characters\`.* TO '${cfg.db_username}'@'localhost';
-            #       GRANT ALL PRIVILEGES ON \`logs\`.* TO '${cfg.db_username}'@'localhost';
-            #       FLUSH PRIVILEGES;
-            #       EOF
-            #
-            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} realmd     < ${cfg.dataPath}/sql/base/realmd.sql
-            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} characters < ${cfg.dataPath}/sql/base/characters.sql
-            #       ${pkgs.mariadb}/bin/mariadb -u ${cfg.db_username} -p${cfg.db_password} mangos     < ${cfg.dataPath}/sql/base/mangos.sql
-            #
-            #       chown -R tortoise-wow ${cfg.dataPath}
-            #       touch ${cfg.dataPath}/.db-initialized
-            #     '';
-            #   };
-            # };
+            systemd.services.tortoise-wow-db-init = {
+              description = "Tortoise-WoW Database Initialization";
+              after = [ "mysql.service" ];
+              requires = [ "mysql.service" ];
+              wantedBy = [ "multi-user.target" ];
+              unitConfig.ConditionPathExists = "!${cfg.dataPath}/.db-initialized";
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+                User = "root";
+                ExecStart = pkgs.writeShellScript "tortoise-wow-db-init" ''
+                  set -e
+                  MYSQL="${pkgs.mariadb}/bin/mariadb"
 
+                  echo "=== Step 1: Creating databases and users ==="
+                  $MYSQL <<SQL
+                    CREATE DATABASE IF NOT EXISTS \`tw_world\`;
+                    CREATE DATABASE IF NOT EXISTS \`tw_char\`;
+                    CREATE DATABASE IF NOT EXISTS \`tw_logon\`;
+                    CREATE DATABASE IF NOT EXISTS \`tw_logs\`;
+                    CREATE USER IF NOT EXISTS '${cfg.db_username}'@'localhost' IDENTIFIED BY '${cfg.db_password}';
+                    GRANT ALL PRIVILEGES ON \`tw_world\`.* TO '${cfg.db_username}'@'localhost';
+                    GRANT ALL PRIVILEGES ON \`tw_char\`.*  TO '${cfg.db_username}'@'localhost';
+                    GRANT ALL PRIVILEGES ON \`tw_logon\`.* TO '${cfg.db_username}'@'localhost';
+                    GRANT ALL PRIVILEGES ON \`tw_logs\`.*  TO '${cfg.db_username}'@'localhost';
+                    FLUSH PRIVILEGES;
+                  SQL
+
+                  echo "=== Step 2: Applying base world tables ==="
+                  for f in ${cfg.dataPath}/sql/base/tw_world_*.sql; do
+                    [ -e "$f" ] || continue
+                    echo "  -> $f"
+                    $MYSQL -f tw_world < "$f"
+                  done
+
+                  echo "=== Step 3: Adding realm entry ==="
+                  $MYSQL tw_logon <<SQL
+                    INSERT INTO realmlist (name, address, port, icon, realmflags, timezone, allowedSecurityLevel, population, realmbuilds)
+                    VALUES ('${cfg.realmName}', '${cfg.address}', 8085, 0, 0, 1, 0, 0, '5875')
+                    ON DUPLICATE KEY UPDATE address=VALUES(address), port=VALUES(port);
+                  SQL
+
+                  chown -R tortoise-wow:tortoise-wow ${cfg.dataPath}
+                  touch ${cfg.dataPath}/.db-initialized
+                  echo "=== Done! ==="
+                '';
+              };
+            };
             systemd.services.tortoise-wow-realmd = {
               after = [
                 "network.target"
@@ -400,7 +412,7 @@
                 Restart = "always";
               };
             };
-            # BUGGED, needs tty, stdin for mangosd console to not reboot each time. Solved for docker, not systemd (yet)
+            # MANGOSD MUST NOT BE IN CONSOLE MODE 
             systemd.services.tortoise-wow-mangosd = {
               after = [ "tortoise-wow-realmd.service" ];
               wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
## Summary

Adds `flake.nix` and `flake.lock` providing a fully reproducible Nix build for tortoise-wow on NixOS and any system with Nix+flakes enabled.

Docker image targets are included for potential use with CI/CD workflows.  Feel free to ignore them if not relevant to your setup.

## What's included

**Packages**
- `tortoise-wow` / `default` — Release build with extractors
- Dev build with `ALLOW_TURTLE_ADDONS` and `USE_REALMMERGE` enabled

**Docker images**
- `realmd-image` / `mangosd-image` — nix2container layered images (push-friendly, smaller layers)
- `realmd-image-tar` / `mangosd-image-tar` — dockerTools tar archives, release
- `realmd-image-tar-dev` / `mangosd-image-tar-dev` — dockerTools tar archives, debug

**Dev shell**
- `nix develop` drops into a shell with all build and native deps

**NixOS module** (`nixosModules.default`)
- Declarative systemd service definitions for `realmd` and `mangosd`
- Configurable: db credentials, realm name, address, data path
- One-shot db-init service that creates databases, users, grants, applies base world SQL
-  `mangosd` must **not** be running in console mode because systemd doesn't like tty's  `Console.Enable = 0` in `mangosd.conf` or the service will hang
- `db_password` is a plain Nix string and ends up in the store (fine for now, bad for production servers)

## Build

```bash
# Build the server
nix build .#tortoise-wow

# Dev shell
nix develop

# Docker images (optional)
nix build .#realmd-image-tar
nix build .#mangosd-image-tar
```

## Supported systems
- `x86_64-linux`
- `aarch64-linux`

## Build patches applied 
- Replaces `find_package(MySQL REQUIRED)` with MariaDB connector
- Drops `-march=native`  in favor of  `-march=x86-64` for portability
- Removes bundled `FindOpenSSL.cmake` in favour of CMake's built-in
- Injects `#include <optional>` into files requiring C++17 compatibility
- Version tied to git rev via `self.shortRev`