### PR TITLE
Add an option to do database autoupdate alphabetically or by file mod time

### DIFF
--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -50,6 +50,12 @@ Database.AutoUpdate.AuthUpdateName = "unused"
 Database.AutoUpdate.CharUpdateName = "unused"
 Database.AutoUpdate.WorldUpdateName = "database_updates"
 
+# Database.AutoUpdate.SortByName. Controls the order in which SQL migration files are applied.  
+#   0 = Sort by file modification time ascending (oldest first); alphabetical name as tiebreaker. (Default)  
+#   1 = Sort alphabetically by file name ascending; modification time as tiebreaker.  
+  
+Database.AutoUpdate.SortByName = 0
+
 # Automatically committing world changes to github. Set to 0 to disable.
 
 AutoCommit.Minutes = 0

--- a/src/shared/Database/AutoUpdater.cpp
+++ b/src/shared/Database/AutoUpdater.cpp
@@ -101,7 +101,7 @@ namespace DBUpdater
         return dbMigrations;
     }
 
-    bool AutoUpdater::ProcessTargetUpdates(const fs::directory_entry& targetPath, DatabaseType* targetDatabase, bool region) const
+    bool AutoUpdater::ProcessTargetUpdates(const fs::directory_entry& targetPath, DatabaseType* targetDatabase, bool region, bool sortByName) const
     {
         auto fileMigrations = LoadFileMigrations(targetPath);
         auto dbMigrations = LoadDatabaseMigrations(targetDatabase);
@@ -138,19 +138,24 @@ namespace DBUpdater
         }
 
         //sort by modified-at ascending for oldest -> newest updates
-        std::sort(updates.begin(), updates.end(), [](const FileMigration& e1, const FileMigration& e2)
-        {
-            if (e1.ModifiedAt < e2.ModifiedAt)
-                return true;
-
-            if (e1.ModifiedAt > e2.ModifiedAt)
-                return false;
-
-
-            //if we're here then both modifiedAt are the same, can happen with Git merges etc. We sort alphabetically by lowest -> oldest first.
-            return e1.Name < e2.Name;
-
-        });
+        // sort order controlled by Database.AutoUpdate.SortByName config  
+        // false (default): sort by modification time ascending, alphabetical name as tiebreaker  
+        // true: sort alphabetically by name ascending, modification time as tiebreaker  
+        std::sort(updates.begin(), updates.end(), [sortByName](const FileMigration& e1, const FileMigration& e2)
+            {
+                if (sortByName)
+                {
+                    if (e1.Name != e2.Name)
+                        return e1.Name < e2.Name;
+                    return e1.ModifiedAt < e2.ModifiedAt;
+                }
+                else
+                {
+                    if (e1.ModifiedAt != e2.ModifiedAt)
+                        return e1.ModifiedAt < e2.ModifiedAt;
+                    return e1.Name < e2.Name;
+                }
+            });
 
         for (const auto& update : updates)
         {
@@ -380,6 +385,7 @@ namespace DBUpdater
         auto authUpdateFolder = sConfig.GetStringDefault("Database.AutoUpdate.AuthUpdateName", "Logon");
         auto charUpdateFolder = sConfig.GetStringDefault("Database.AutoUpdate.CharUpdateName", "Char");
         auto worldUpdateFolder = sConfig.GetStringDefault("Database.AutoUpdate.WorldUpdateName", "World");
+        bool sortByName = sConfig.GetBoolDefault("Database.AutoUpdate.SortByName", false);
         path folderPath{ pathString };
 
 
@@ -387,13 +393,13 @@ namespace DBUpdater
         directory_entry charUpdatePath{ folderPath / charUpdateFolder };
         directory_entry worldUpdatePath{ folderPath / worldUpdateFolder };
 
-        if (!ProcessTargetUpdates(logonUpdatePath, &LoginDatabase, false))
+        if (!ProcessTargetUpdates(logonUpdatePath, &LoginDatabase, false, sortByName))
             return false;
 
-        if (!ProcessTargetUpdates(charUpdatePath, &CharacterDatabase, false))
+        if (!ProcessTargetUpdates(charUpdatePath, &CharacterDatabase, false, sortByName))
             return false;
 
-        if (!ProcessTargetUpdates(worldUpdatePath, &WorldDatabase, false))
+        if (!ProcessTargetUpdates(worldUpdatePath, &WorldDatabase, false, sortByName))
             return false;
 
 
@@ -408,13 +414,13 @@ namespace DBUpdater
             directory_entry cnWorldPath{ worldUpdatePath.path() / "cn" };
 
 
-            if (!ProcessTargetUpdates(cnLogonPath, &LoginDatabase, true))
+            if (!ProcessTargetUpdates(cnLogonPath, &LoginDatabase, true, sortByName))
                 return false;
 
-            if (!ProcessTargetUpdates(cnCharPath, &CharacterDatabase, true))
+            if (!ProcessTargetUpdates(cnCharPath, &CharacterDatabase, true, sortByName))
                 return false;
 
-            if (!ProcessTargetUpdates(cnWorldPath, &WorldDatabase, true))
+            if (!ProcessTargetUpdates(cnWorldPath, &WorldDatabase, true, sortByName))
                 return false;
         }
 

--- a/src/shared/Database/AutoUpdater.hpp
+++ b/src/shared/Database/AutoUpdater.hpp
@@ -39,7 +39,7 @@ namespace DBUpdater
 
         bool ExecuteUpdate(const FileMigration& fileData, DatabaseType* targetDatabase) const;
 
-        bool ProcessTargetUpdates(const fs::directory_entry& targetPath, DatabaseType* targetDatabase, bool region) const;
+        bool ProcessTargetUpdates(const fs::directory_entry& targetPath, DatabaseType* targetDatabase, bool region, bool sortByName) const;
 
         std::unordered_map<std::string, FileMigration> LoadFileMigrations(const std::filesystem::directory_entry& targetPath) const;
         std::unordered_map<std::string, Migration> LoadDatabaseMigrations(DatabaseType* targetDatabase) const;


### PR DESCRIPTION
## Issue this resolves
<!-- Please link to an issue. Create one first if needed. -->
- Closes #289

## Code Type
- [ ]  SQL
- [X]  Core

## Description
<!-- What was changed? Why was it necessary? Any relevant context? -->
## Summary  
  
Fixed auto database updater migrations out of order when SQL files are retroactively modified 
  
## Problem  
  
The auto-updater sorts SQL migration files by filesystem modification time. 
When a migration file is retroactively modified (e.g. a fix is appended), its modification timestamp is updated to the current time. 
This causes it to sort after newer migrations that were never touched, breaking the intended chronological order encoded in the filenames.
  
### Files changed
| File | Change |
|---|---|
| `src/mangosd/mangosd.conf.dist.in` | add Database.AutoUpdate.SortByName option to config template |
| `src/shared/Database/AutoUpdater.cpp` | implement Database.AutoUpdate.SortByName option |
| `src/shared/Database/AutoUpdater.hpp` | implement Database.AutoUpdate.SortByName option |