### PR TITLE
Rogue talent fix: Shadow of Death and Envenom Wound Poison scaling and Improved Ambush

### DIFF
--- a/sql/wip_updates/spell_affect.sql
+++ b/sql/wip_updates/spell_affect.sql
@@ -1,0 +1,4 @@
+-- Issue #314: Envenom (52531) should also affect Wound Poison, matching Improved Poisons.
+INSERT INTO `spell_affect` (`entry`, `effectId`, `SpellFamilyMask`) VALUES
+(52531, 1, 268558336),
+(52531, 2, 268558336);

--- a/sql/wip_updates/spell_proc_event.sql
+++ b/sql/wip_updates/spell_proc_event.sql
@@ -1,0 +1,2 @@
+-- Improved Ambush (14079/14080/14081): SpellFamilyMask0 also matched non-Ambush combo moves; restrict to CF_ROGUE_AMBUSH only.
+UPDATE `spell_proc_event` SET `SpellFamilyMask0` = 512 WHERE `entry` IN (14079, 14080, 14081) AND `SpellFamilyMask0` = 8389120;

--- a/sql/wip_updates/spell_template.sql
+++ b/sql/wip_updates/spell_template.sql
@@ -1,0 +1,2 @@
+-- Issue #314: bind Shadow of Death (52710) to its new spell script.
+UPDATE `spell_template` SET `script_name` = 'spell_rogue_shadow_of_death' WHERE `entry` = 52710;

--- a/src/scripts/spells/spell_rogue.cpp
+++ b/src/scripts/spells/spell_rogue.cpp
@@ -262,6 +262,49 @@ struct spell_rogue_improved_ambush : public AuraScript
     }
 };
 
+struct spell_rogue_shadow_of_death : public AuraScript
+{
+    uint8 m_comboPoints = 0;
+    int32 m_maxDamage = 0;
+    int32 m_accumulatedDamage = 0;
+
+    void OnAfterApply(Aura* aura, bool apply) override
+    {
+        Unit* caster = aura->GetCaster();
+        if (apply)
+        {
+            if (caster && caster->IsPlayer())
+            {
+                m_comboPoints = caster->ToPlayer()->GetComboPoints();
+                m_maxDamage = int32(caster->GetTotalAttackPowerValue(BASE_ATTACK) * m_comboPoints) / 2;
+            }
+        }
+        else
+        {
+            Unit* target = aura->GetTarget();
+
+            if (m_accumulatedDamage > 0 && target->IsAlive() && caster && caster->IsAlive())
+                caster->CastCustomSpell(target, 52711, &m_accumulatedDamage, nullptr, nullptr, true, nullptr, aura);
+        }
+    }
+
+    std::optional<SpellAuraProcResult> OnProc(Unit* owner, Unit* /*victim*/, uint32 damage, int32 /*originalAmount*/, Aura* aura, SpellEntry const* /*procSpell*/, uint32 /*procFlag*/, uint32 /*procEx*/, uint32 /*cooldown*/) override
+    {
+        Unit* auraCaster = aura->GetCaster();
+        if (!auraCaster || !auraCaster->IsAlive() || !m_comboPoints)
+            return SPELL_AURA_PROC_FAILED;
+
+        m_accumulatedDamage = std::min(m_accumulatedDamage + int32(damage * 0.1f * m_comboPoints), m_maxDamage);
+
+        bool const capped = m_accumulatedDamage >= m_maxDamage;
+
+        if (capped)
+            owner->RemoveAurasDueToSpell(52710);
+
+        return SPELL_AURA_PROC_OK;
+    }
+};
+
 struct spell_rogue_improved_sap_vanish : public SpellScript
 {
     void OnEffectExecuted(Spell* spell, SpellEffectIndex effIdx) const override
@@ -286,5 +329,6 @@ void AddSC_rogue_spell_scripts()
     RegisterAuraScript("spell_rogue_clean_escape", &GetAuraScript<spell_rogue_clean_escape>);
     RegisterAuraScript("spell_rogue_blade_flurry", &GetAuraScript<spell_rogue_blade_flurry>);
     RegisterAuraScript("spell_rogue_improved_ambush", &GetAuraScript<spell_rogue_improved_ambush>);
+    RegisterAuraScript("spell_rogue_shadow_of_death", &GetAuraScript<spell_rogue_shadow_of_death>);
     RegisterSpellScript("spell_rogue_improved_sap_vanish", &GetSpellScript<spell_rogue_improved_sap_vanish>);
 }


### PR DESCRIPTION
Refs #314
Refs #348 

## Issue this resolves
https://github.com/Penqle/tortoise-wow/issues/314
https://github.com/Penqle/tortoise-wow/issues/348
## Code Type
- [x]  SQL
- [x]  Core

## Description
1st fix: Shadow of Death dummy aura implementation

UPDATE: Fixed it in the new approach without having to fiddle around with bit logic 

2nd fix: 
according to dev changes on forum wound poison should be affected by envenom effectiveness increase
this fix is not exact - it is too low by 2,5% at 5 stacks but I think this is acceptable 

3rd fix:
Improved ambush talent no longer applies to non ambush combo generators
